### PR TITLE
(feature) basic account and user CRUD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/*coverage*

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+linters-settings:
+  errcheck:
+    exclude-functions:
+      - (*go.uber.org/zap.Logger).Sync

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -41,6 +41,8 @@ func run() error {
 	services := http.Services{
 		ToggleService:   togglr.NewToggleService(db, db, log),
 		MetadataService: db,
+		AccountService:  db,
+		UserService:     db,
 		Resolver:        togglr.NewResolver(db),
 	}
 

--- a/hmac/hmac.go
+++ b/hmac/hmac.go
@@ -1,0 +1,71 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha512"
+	"errors"
+
+	"github.com/togglr-io/togglr/env"
+)
+
+// our hmac hashes are 512 bits in length, so we're grabbing the byte length
+const hmacHashLength = 512 / 8
+
+// A Signer implements the togglr.Signer interface using HMACSHA512 to generate signatures
+type Signer struct {
+	secret []byte
+}
+
+// NewSigner creates a new Signer with the given key
+func NewSigner(secret string) Signer {
+	return Signer{
+		secret: []byte(secret),
+	}
+}
+
+// FromEnv creates a new Signer using a secret found at some environment key
+func FromEnv(key string) Signer {
+	return NewSigner(env.GetString(key, "TOGGLR_SIGNING_KEY"))
+}
+
+func (s Signer) getSignature(data []byte) ([]byte, error) {
+	mac := hmac.New(sha512.New, s.secret)
+	if _, err := mac.Write(data); err != nil {
+		return nil, err
+	}
+
+	return mac.Sum(nil), nil
+}
+
+// Sign some data using HMACSHA512 and the configured key
+func (s Signer) Sign(data []byte) ([]byte, error) {
+	sig, err := s.getSignature(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(data, sig...), nil
+}
+
+// Validate some signed data, returning the original payload if validation succeeds
+func (s Signer) Validate(signed []byte) ([]byte, error) {
+	sigStart := len(signed) - hmacHashLength
+	data := signed[:sigStart]
+	signature := signed[sigStart:]
+
+	// sign the source data and compare it to the signature given
+	expected, err := s.getSignature(data)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, b := range signature {
+		// if the signature given doesn't match the new signature,
+		// the payload is invalid
+		if b != expected[i] {
+			return nil, errors.New("invalid signature")
+		}
+	}
+
+	return signed, nil
+}

--- a/hmac/hmac_test.go
+++ b/hmac/hmac_test.go
@@ -1,0 +1,29 @@
+package hmac_test
+
+import (
+	"testing"
+
+	"github.com/togglr-io/togglr/hmac"
+)
+
+func Test_Signer(t *testing.T) {
+	secret := "testing"
+	signer := hmac.NewSigner(secret)
+	src := []byte("Hello, world!")
+
+	signed, err := signer.Sign(src)
+	if err != nil {
+		t.Fatal("failed to sign data")
+	}
+
+	original, err := signer.Validate(signed)
+	if err != nil {
+		t.Fatalf("failed to validate signed data: %s", err)
+	}
+
+	for idx, b := range src {
+		if b != original[idx] {
+			t.Fatal("decoded data does not match src")
+		}
+	}
+}

--- a/http/account.go
+++ b/http/account.go
@@ -1,0 +1,216 @@
+package http
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/togglr-io/togglr"
+	"github.com/togglr-io/togglr/uid"
+	"go.uber.org/zap"
+)
+
+// HandleAccountPOST handles POST requests to the /account endpoint
+func HandleAccountPOST(log *zap.Logger, as togglr.AccountService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleAccountPOST"))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Debug("creating account")
+		defer log.Sync()
+
+		var id togglr.ID
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Error("failed to read request", zap.Error(err))
+			serverError(w, "could not read request")
+			return
+		}
+
+		if err := json.Unmarshal(body, &id); err != nil {
+			log.Error("failed to unmarshal ID from request", zap.Error(err))
+			badRequest(w, "could not unmarshal account")
+			return
+		}
+
+		// whether or not the Account has an ID determines if we're creating a new one or
+		// updating an existing one
+		if id.ID.IsNull() {
+			var account togglr.Account
+			if err := json.Unmarshal(body, &account); err != nil {
+				log.Error("failed to unmarshal account", zap.Error(err))
+				badRequest(w, "could not unmarshal account")
+				return
+			}
+
+			id.ID, err = as.CreateAccount(r.Context(), account)
+			if err != nil {
+				log.Error("failed to create account", zap.Error(err))
+				serverError(w, "could not save account")
+				return
+			}
+		} else {
+			var updateReq togglr.UpdateAccountReq
+			if err := json.Unmarshal(body, &updateReq); err != nil {
+				log.Error("failed to unmarshal update req", zap.Error(err))
+				badRequest(w, "could not unmarshal account")
+				return
+			}
+
+			if err := as.UpdateAccount(r.Context(), updateReq); err != nil {
+				log.Error("failed to update account", zap.Error(err))
+				serverError(w, "could not save account")
+				return
+			}
+		}
+
+		data, err := json.Marshal(id)
+		if err != nil {
+			log.Error("failed to marshal response", zap.Error(err))
+			serverError(w, "could not create account")
+			return
+		}
+
+		ok(w, data)
+	})
+}
+
+// HandleAccountGET handles GET requests to the /account endpoint
+func HandleAccountGET(log *zap.Logger, as togglr.AccountService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleAccountGET"))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Debug("listing accounts")
+		defer log.Sync()
+
+		req := togglr.ListAccountsReq{}
+
+		accounts, err := as.ListAccounts(r.Context(), req)
+		if err != nil {
+			log.Error("failed to list accounts", zap.Error(err))
+			serverError(w, "could not list accounts")
+			return
+		}
+
+		data, err := json.Marshal(accounts)
+		if err != nil {
+			log.Error("failed to marshal accounts", zap.Error(err))
+			serverError(w, "could not list accounts")
+			return
+		}
+
+		ok(w, data)
+	})
+}
+
+// HandleAccountIdGET handles GET requests to the /account/{id} endpoint
+func HandleAccountIdGET(log *zap.Logger, as togglr.AccountService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleAccountIdGET"))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		log = log.With(zap.String("accountID", id))
+		log.Debug("fetching account")
+		defer log.Sync()
+
+		uid, err := uid.FromString(id)
+		if err != nil {
+			log.Error("failed to parse account ID", zap.Error(err))
+			badRequest(w, "account ID was badly formed")
+			return
+		}
+
+		account, err := as.FetchAccount(r.Context(), uid)
+		if err != nil {
+			log.Error("failed to fetch account", zap.Error(err))
+			serverError(w, "could not fetch account")
+			return
+		}
+
+		data, err := json.Marshal(account)
+		if err != nil {
+			log.Error("failed to marshal account", zap.Error(err))
+			serverError(w, "could not fetch account")
+			return
+		}
+
+		ok(w, data)
+	})
+}
+
+// HandleAccountUsersGET handles GET requests to the /account/{id} endpoint
+func HandleAccountUsersGET(log *zap.Logger, us togglr.UserService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleAccountUsersGET"))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		log = log.With(zap.String("accountID", id))
+		log.Debug("listing account users")
+		defer log.Sync()
+
+		uid, err := uid.FromString(id)
+		if err != nil {
+			log.Error("failed to parse account ID", zap.Error(err))
+			badRequest(w, "account ID was badly formed")
+			return
+		}
+
+		req := togglr.ListUsersReq{
+			AccountID: uid,
+		}
+
+		users, err := us.ListUsers(r.Context(), req)
+		if err != nil {
+			log.Error("failed to fetch account users", zap.Error(err))
+			serverError(w, "could not fetch account users")
+			return
+		}
+
+		data, err := json.Marshal(users)
+		if err != nil {
+			log.Error("failed to marshal account", zap.Error(err))
+			serverError(w, "could not fetch account")
+			return
+		}
+
+		ok(w, data)
+	})
+}
+
+// HandleAccountUsersPOST handles POST requests to the /account/{id}/user endpoint
+func HandleAccountUsersPOST(log *zap.Logger, as togglr.AccountService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleAccountUsersPOST"))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		log = log.With(zap.String("accountID", id))
+		log.Debug("updating account users")
+		defer log.Sync()
+
+		accountID, err := uid.FromString(id)
+		if err != nil {
+			log.Error("failed to parse account ID", zap.Error(err))
+			badRequest(w, "account ID was badly formed")
+			return
+		}
+
+		var req togglr.UpdateAccountUsersReq
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Error("failed to read request", zap.Error(err))
+			serverError(w, "could not read request")
+			return
+		}
+
+		if err := json.Unmarshal(body, &req); err != nil {
+			log.Error("failed to unmarshal user ID from request", zap.Error(err))
+			badRequest(w, "could not unmarshal account")
+			return
+		}
+
+		if err := as.UpdateAccountUsers(r.Context(), accountID, req); err != nil {
+			log.Error("failed to add users", zap.Error(err))
+			serverError(w, "could not add users to account")
+			return
+		}
+
+		noContent(w)
+	})
+}

--- a/http/account_test.go
+++ b/http/account_test.go
@@ -1,0 +1,161 @@
+package http_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/togglr-io/togglr/http"
+	"github.com/togglr-io/togglr/mock"
+	"github.com/togglr-io/togglr/uid"
+	"go.uber.org/zap"
+)
+
+func Test_HandleAccountPOST(t *testing.T) {
+	id := uid.New().String()
+	cases := []struct {
+		name                string
+		payload             string
+		accountService      *mock.AccountService
+		expectedStatus      int
+		expectedCreateCalls int
+		expectedUpdateCalls int
+	}{
+		{
+			name:                "successful create",
+			payload:             `{"name": "Test Account"}`,
+			accountService:      mock.NewAccountService(nil),
+			expectedStatus:      200,
+			expectedCreateCalls: 1,
+			expectedUpdateCalls: 0,
+		},
+		{
+			name:                "bad request",
+			payload:             `{"name": invalid"Test Account"}`,
+			accountService:      mock.NewAccountService(nil),
+			expectedStatus:      400,
+			expectedCreateCalls: 0,
+			expectedUpdateCalls: 0,
+		},
+		{
+			name:                "failed create",
+			payload:             `{"name": "Test Account"}`,
+			accountService:      mock.NewAccountService(errors.New("forced")),
+			expectedStatus:      500,
+			expectedCreateCalls: 1,
+			expectedUpdateCalls: 0,
+		},
+		{
+			name:                "successful update",
+			payload:             fmt.Sprintf(`{"id": "%s", "name": "New Account"}`, id),
+			accountService:      mock.NewAccountService(nil),
+			expectedStatus:      200,
+			expectedCreateCalls: 0,
+			expectedUpdateCalls: 1,
+		},
+		{
+			name:                "failed update",
+			payload:             fmt.Sprintf(`{"id": "%s", "name": "New Account"}`, id),
+			accountService:      mock.NewAccountService(errors.New("forced")),
+			expectedStatus:      500,
+			expectedCreateCalls: 0,
+			expectedUpdateCalls: 1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := http.Config{
+				Logger: zap.NewNop(),
+				Services: http.Services{
+					AccountService: c.accountService,
+				},
+			}
+
+			s := httptest.NewServer(http.BuildRoutes(cfg))
+			defer s.Close()
+			url := fmt.Sprintf("%s/account", s.URL)
+			req, err := stdhttp.NewRequest("POST", url, bytes.NewReader([]byte(c.payload)))
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err)
+			}
+
+			res, err := stdhttp.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("failed to send request: %s", err)
+			}
+
+			if res.StatusCode != c.expectedStatus {
+				t.Fatalf("expected status code of %d, but got %d", c.expectedStatus, res.StatusCode)
+			}
+
+			if c.accountService.CreateAccountCalled != c.expectedCreateCalls {
+				t.Fatalf("expected CreateAccount account to be called %d times, but it was called %d times", c.expectedCreateCalls, c.accountService.CreateAccountCalled)
+			}
+
+			if c.accountService.UpdateAccountCalled != c.expectedUpdateCalls {
+				t.Fatalf("expected UpdateAccount account to be called %d times, but it was called %d times", c.expectedUpdateCalls, c.accountService.UpdateAccountCalled)
+			}
+		})
+	}
+}
+
+func Test_HandleAccountGet(t *testing.T) {
+	cases := []struct {
+		name           string
+		query          string
+		accountService *mock.AccountService
+		expectedStatus int
+		expectedCalls  int
+	}{
+		{
+			name:           "successful test",
+			query:          "",
+			accountService: mock.NewAccountService(nil),
+			expectedStatus: 200,
+			expectedCalls:  1,
+		},
+		{
+			name:           "service failure",
+			query:          "",
+			accountService: mock.NewAccountService(errors.New("forced")),
+			expectedStatus: 500,
+			expectedCalls:  1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := http.Config{
+				Logger: zap.NewNop(),
+				Services: http.Services{
+					AccountService: c.accountService,
+				},
+			}
+
+			s := httptest.NewServer(http.BuildRoutes(cfg))
+			defer s.Close()
+			url := fmt.Sprintf("%s/account?%s", s.URL, c.query)
+			req, err := stdhttp.NewRequest("GET", url, nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err)
+			}
+
+			res, err := stdhttp.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("failed to send request: %s", err)
+			}
+
+			if res.StatusCode != c.expectedStatus {
+				t.Fatalf("expected status code of %d, but got %d", c.expectedStatus, res.StatusCode)
+			}
+
+			if c.accountService.ListAccountsCalled != c.expectedCalls {
+				t.Fatalf("expected FetchAccount account to be called %d times, but it was called %d times", c.expectedCalls, c.accountService.CreateAccountCalled)
+			}
+		})
+	}
+}

--- a/http/http.go
+++ b/http/http.go
@@ -15,6 +15,8 @@ import (
 type Services struct {
 	ToggleService   togglr.ToggleService
 	MetadataService togglr.MetadataService
+	AccountService  togglr.AccountService
+	UserService     togglr.UserService
 	Resolver        togglr.Resolver
 }
 
@@ -38,13 +40,25 @@ func BuildRoutes(cfg Config) chi.Router {
 		AllowedOrigins: []string{"http://localhost:3000", "http://localhost:9001"},
 	}))
 
-	r.Post("/toggle", HandleTogglePost(cfg.Logger, cfg.Services.ToggleService))
-	r.Get("/toggle", HandleToggleGet(cfg.Logger, cfg.Services.ToggleService))
-	r.Get("/toggle/{id}", HandleToggleGetID(cfg.Logger, cfg.Services.ToggleService))
-	r.Delete("/toggle/{id}", HandleToggleDelete(cfg.Logger, cfg.Services.ToggleService))
+	r.Post("/toggle", HandleTogglePOST(cfg.Logger, cfg.Services.ToggleService))
+	r.Get("/toggle", HandleToggleGET(cfg.Logger, cfg.Services.ToggleService))
+	r.Get("/toggle/{id}", HandleToggleIdGET(cfg.Logger, cfg.Services.ToggleService))
+	r.Delete("/toggle/{id}", HandleToggleDELETE(cfg.Logger, cfg.Services.ToggleService))
 
-	r.Get("/metadata/{accountID}", HandleMetadataGet(cfg.Logger, cfg.Services.MetadataService))
-	r.Post("/resolve/{accountID}", HandleResolvePost(cfg.Logger, cfg.Services.Resolver))
+	r.Get("/metadata/{accountID}", HandleMetadataGET(cfg.Logger, cfg.Services.MetadataService))
+	r.Post("/resolve/{accountID}", HandleResolvePOST(cfg.Logger, cfg.Services.Resolver))
+
+	r.Post("/account", HandleAccountPOST(cfg.Logger, cfg.Services.AccountService))
+	r.Get("/account", HandleAccountGET(cfg.Logger, cfg.Services.AccountService))
+	r.Get("/account/{id}", HandleAccountIdGET(cfg.Logger, cfg.Services.AccountService))
+	r.Get("/account/{id}/user", HandleAccountUsersGET(cfg.Logger, cfg.Services.UserService))
+	r.Post("/account/{id}/user", HandleAccountUsersPOST(cfg.Logger, cfg.Services.AccountService))
+
+	r.Post("/user", HandleUserPOST(cfg.Logger, cfg.Services.UserService))
+	// a GET on /user returns the currently logged in user
+	r.Get("/user", HandleUserGET(cfg.Logger, cfg.Services.UserService))
+	r.Get("/user/{id}", HandleUserIdGET(cfg.Logger, cfg.Services.UserService))
+	r.Delete("/user/{id}", HandleUserDELETE(cfg.Logger, cfg.Services.UserService))
 
 	return r
 }

--- a/http/metadata.go
+++ b/http/metadata.go
@@ -10,8 +10,8 @@ import (
 	"go.uber.org/zap"
 )
 
-func HandleMetadataGet(log *zap.Logger, ms togglr.MetadataService) http.HandlerFunc {
-	log = log.With(zap.String("handler", "handleGetMetadata"))
+func HandleMetadataGET(log *zap.Logger, ms togglr.MetadataService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "handleMetadataGET"))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accountID := chi.URLParam(r, "accountID")

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -31,7 +31,7 @@ func Telemetry(logger *zap.Logger) Middleware {
 			start := time.Now()
 			requestID := uuid.New().String()
 			newCtx := WithRequestID(r.Context(), requestID)
-			r.WithContext(newCtx)
+			r = r.WithContext(newCtx)
 			logger = logger.With(
 				zap.String("path", r.URL.String()),
 				zap.String("method", r.Method),

--- a/http/resolver.go
+++ b/http/resolver.go
@@ -13,8 +13,8 @@ import (
 )
 
 // HandleResolvePost handles POST requests to the /resolve endpoint
-func HandleResolvePost(log *zap.Logger, resolver togglr.Resolver) http.HandlerFunc {
-	log = log.With(zap.String("handler", "handleResolverPost"))
+func HandleResolvePOST(log *zap.Logger, resolver togglr.Resolver) http.HandlerFunc {
+	log = log.With(zap.String("handler", "handleResolvePOST"))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accountID := chi.URLParam(r, "accountID")

--- a/http/status.go
+++ b/http/status.go
@@ -5,30 +5,32 @@ import "net/http"
 func ok(w http.ResponseWriter, data []byte) {
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(data)
+	_, _ = w.Write(data)
 }
 
 func noContent(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusNoContent)
-	w.Write(nil)
+	_, _ = w.Write(nil)
 }
 
 func badRequest(w http.ResponseWriter, msg string) {
 	w.WriteHeader(http.StatusBadRequest)
-	w.Write([]byte(msg))
+	_, _ = w.Write([]byte(msg))
 }
 
+// nolint
 func forbidden(w http.ResponseWriter, msg string) {
 	w.WriteHeader(http.StatusForbidden)
-	w.Write([]byte(msg))
+	_, _ = w.Write([]byte(msg))
 }
 
+// nolint
 func unauthorized(w http.ResponseWriter, msg string) {
 	w.WriteHeader(http.StatusUnauthorized)
-	w.Write([]byte(msg))
+	_, _ = w.Write([]byte(msg))
 }
 
 func serverError(w http.ResponseWriter, msg string) {
 	w.WriteHeader(http.StatusInternalServerError)
-	w.Write([]byte(msg))
+	_, _ = w.Write([]byte(msg))
 }

--- a/http/toggle.go
+++ b/http/toggle.go
@@ -11,9 +11,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// HandleTogglePost handles POST requests to the /toggle endpoint
-func HandleTogglePost(log *zap.Logger, ts togglr.ToggleService) http.HandlerFunc {
-	log = log.With(zap.String("handler", "handleTogglePost"))
+// HandleTogglePOST handles POST requests to the /toggle endpoint
+func HandleTogglePOST(log *zap.Logger, ts togglr.ToggleService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleTogglePOST"))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Debug("creating toggle")
@@ -75,9 +75,9 @@ func HandleTogglePost(log *zap.Logger, ts togglr.ToggleService) http.HandlerFunc
 	})
 }
 
-// HandleToggleGet handles GET requests to the /toggle endpoint
-func HandleToggleGet(log *zap.Logger, ts togglr.ToggleService) http.HandlerFunc {
-	log = log.With(zap.String("handler", "handleToggleList"))
+// HandleToggleGET handles GET requests to the /toggle endpoint
+func HandleToggleGET(log *zap.Logger, ts togglr.ToggleService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleToggleGET"))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Debug("listing toggles")
 		defer log.Sync()
@@ -102,8 +102,10 @@ func HandleToggleGet(log *zap.Logger, ts togglr.ToggleService) http.HandlerFunc 
 	})
 }
 
-// HandleToggleGetID handles GET requests to the /toggle/{id} endpoint
-func HandleToggleGetID(log *zap.Logger, ts togglr.ToggleService) http.HandlerFunc {
+// HandleToggleGetIdGET handles GET requests to the /toggle/{id} endpoint
+func HandleToggleIdGET(log *zap.Logger, ts togglr.ToggleService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleToggleIdGET"))
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		log = log.With(zap.String("toggleID", id))
@@ -135,8 +137,10 @@ func HandleToggleGetID(log *zap.Logger, ts togglr.ToggleService) http.HandlerFun
 	})
 }
 
-// HandleToggleDelete handles DELETE requests to the /toggle/{id} endpoint
-func HandleToggleDelete(log *zap.Logger, ts togglr.ToggleService) http.HandlerFunc {
+// HandleToggleDELETE handles DELETE requests to the /toggle/{id} endpoint
+func HandleToggleDELETE(log *zap.Logger, ts togglr.ToggleService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleToggleDELETE"))
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		log = log.With(zap.String("toggleID", id))

--- a/http/user.go
+++ b/http/user.go
@@ -1,0 +1,164 @@
+package http
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/togglr-io/togglr"
+	"github.com/togglr-io/togglr/uid"
+	"go.uber.org/zap"
+)
+
+// HandleUserPOST handles POST requests to the /user endpoint
+func HandleUserPOST(log *zap.Logger, as togglr.UserService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleUserPOST"))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Debug("creating user")
+		defer log.Sync()
+
+		var id togglr.ID
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Error("failed to read request", zap.Error(err))
+			serverError(w, "could not read request")
+			return
+		}
+
+		if err := json.Unmarshal(body, &id); err != nil {
+			log.Error("failed to unmarshal ID from request", zap.Error(err))
+			badRequest(w, "could not unmarshal user")
+			return
+		}
+
+		// whether or not the User has an ID determines if we're creating a new one or
+		// updating an existing one
+		if id.ID.IsNull() {
+			var user togglr.User
+			if err := json.Unmarshal(body, &user); err != nil {
+				log.Error("failed to unmarshal user", zap.Error(err))
+				badRequest(w, "could not unmarshal user")
+				return
+			}
+
+			id.ID, err = as.CreateUser(r.Context(), user)
+			if err != nil {
+				log.Error("failed to create user", zap.Error(err))
+				serverError(w, "could not save user")
+				return
+			}
+		} else {
+			var updateReq togglr.UpdateUserReq
+			if err := json.Unmarshal(body, &updateReq); err != nil {
+				log.Error("failed to unmarshal update req", zap.Error(err))
+				badRequest(w, "could not unmarshal user")
+				return
+			}
+
+			if err := as.UpdateUser(r.Context(), updateReq); err != nil {
+				log.Error("failed to update user", zap.Error(err))
+				serverError(w, "could not save user")
+				return
+			}
+		}
+
+		data, err := json.Marshal(id)
+		if err != nil {
+			log.Error("failed to marshal response", zap.Error(err))
+			serverError(w, "could not create user")
+			return
+		}
+
+		ok(w, data)
+	})
+}
+
+// HandleUserGET handles GET requests to the /user endpoint
+func HandleUserGET(log *zap.Logger, as togglr.UserService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleUserGET"))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Debug("listing users")
+		defer log.Sync()
+
+		req := togglr.ListUsersReq{}
+
+		users, err := as.ListUsers(r.Context(), req)
+		if err != nil {
+			log.Error("failed to list users", zap.Error(err))
+			serverError(w, "could not list users")
+			return
+		}
+
+		data, err := json.Marshal(users)
+		if err != nil {
+			log.Error("failed to marshal users", zap.Error(err))
+			serverError(w, "could not list users")
+			return
+		}
+
+		ok(w, data)
+	})
+}
+
+// HandleUserIdGET handles GET requests to the /user/{id} endpoint
+func HandleUserIdGET(log *zap.Logger, as togglr.UserService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleUserIdGET"))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		log = log.With(zap.String("userID", id))
+		log.Debug("fetching user")
+		defer log.Sync()
+
+		uid, err := uid.FromString(id)
+		if err != nil {
+			log.Error("failed to parse user ID", zap.Error(err))
+			badRequest(w, "user ID was badly formed")
+			return
+		}
+
+		user, err := as.FetchUser(r.Context(), uid)
+		if err != nil {
+			log.Error("failed to fetch user", zap.Error(err))
+			serverError(w, "could not fetch user")
+			return
+		}
+
+		data, err := json.Marshal(user)
+		if err != nil {
+			log.Error("failed to marshal user", zap.Error(err))
+			serverError(w, "could not fetch user")
+			return
+		}
+
+		ok(w, data)
+	})
+}
+
+// HandleUserDELETE handles DELETE requests to the /user/{id} endpoint
+func HandleUserDELETE(log *zap.Logger, ts togglr.UserService) http.HandlerFunc {
+	log = log.With(zap.String("handler", "HandleUserDELETE"))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		log = log.With(zap.String("userID", id))
+		log.Debug("deleting user")
+		defer log.Sync()
+
+		uid, err := uid.FromString(id)
+		if err != nil {
+			log.Error("failed to parse user ID", zap.Error(err))
+			badRequest(w, "user ID was badly formed")
+			return
+		}
+
+		if err := ts.DeleteUser(r.Context(), uid); err != nil {
+			log.Error("failed to delete user", zap.Error(err))
+			serverError(w, "could not delete user")
+			return
+		}
+
+		noContent(w)
+	})
+}

--- a/http/user_test.go
+++ b/http/user_test.go
@@ -1,0 +1,226 @@
+package http_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/togglr-io/togglr/http"
+	"github.com/togglr-io/togglr/mock"
+	"github.com/togglr-io/togglr/uid"
+	"go.uber.org/zap"
+)
+
+func Test_HandleUserPost(t *testing.T) {
+	accountID := uid.New().String()
+	id := uid.New().String()
+	cases := []struct {
+		name                string
+		payload             string
+		userService         *mock.UserService
+		expectedStatus      int
+		expectedCreateCalls int
+		expectedUpdateCalls int
+	}{
+		{
+			name:                "successful create",
+			payload:             fmt.Sprintf(`{"accountId": "%s", "email": "test@togglr.io"}`, accountID),
+			userService:         mock.NewUserService(nil),
+			expectedStatus:      200,
+			expectedCreateCalls: 1,
+			expectedUpdateCalls: 0,
+		},
+		{
+			name:                "bad request",
+			payload:             `{"accountId": invalid, "email": "test@togglr.io"}`,
+			userService:         mock.NewUserService(nil),
+			expectedStatus:      400,
+			expectedCreateCalls: 0,
+			expectedUpdateCalls: 0,
+		},
+		{
+			name:                "failed create",
+			payload:             fmt.Sprintf(`{"accountId": "%s", "email": "test@togglr.io"}`, accountID),
+			userService:         mock.NewUserService(errors.New("forced")),
+			expectedStatus:      500,
+			expectedCreateCalls: 1,
+			expectedUpdateCalls: 0,
+		},
+		{
+			name:                "successful update",
+			payload:             fmt.Sprintf(`{"id": "%s", "name": "Test User"}`, id),
+			userService:         mock.NewUserService(nil),
+			expectedStatus:      200,
+			expectedCreateCalls: 0,
+			expectedUpdateCalls: 1,
+		},
+		{
+			name:                "failed update",
+			payload:             fmt.Sprintf(`{"id": "%s", "name": "Test User"}`, id),
+			userService:         mock.NewUserService(errors.New("forced")),
+			expectedStatus:      500,
+			expectedCreateCalls: 0,
+			expectedUpdateCalls: 1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := http.Config{
+				Logger: zap.NewNop(),
+				Services: http.Services{
+					UserService: c.userService,
+				},
+			}
+
+			s := httptest.NewServer(http.BuildRoutes(cfg))
+			defer s.Close()
+			url := fmt.Sprintf("%s/user", s.URL)
+			req, err := stdhttp.NewRequest("POST", url, bytes.NewReader([]byte(c.payload)))
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err)
+			}
+
+			res, err := stdhttp.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("failed to send request: %s", err)
+			}
+
+			if res.StatusCode != c.expectedStatus {
+				t.Fatalf("expected status code of %d, but got %d", c.expectedStatus, res.StatusCode)
+			}
+
+			if c.userService.CreateUserCalled != c.expectedCreateCalls {
+				t.Fatalf("expected CreateUser user to be called %d times, but it was called %d times", c.expectedCreateCalls, c.userService.CreateUserCalled)
+			}
+
+			if c.userService.UpdateUserCalled != c.expectedUpdateCalls {
+				t.Fatalf("expected UpdateUser user to be called %d times, but it was called %d times", c.expectedUpdateCalls, c.userService.UpdateUserCalled)
+			}
+		})
+	}
+}
+
+func Test_HandleUserGet(t *testing.T) {
+	cases := []struct {
+		name           string
+		query          string
+		userService    *mock.UserService
+		expectedStatus int
+		expectedCalls  int
+	}{
+		{
+			name:           "successful test",
+			query:          "",
+			userService:    mock.NewUserService(nil),
+			expectedStatus: 200,
+			expectedCalls:  1,
+		},
+		{
+			name:           "service failure",
+			query:          "",
+			userService:    mock.NewUserService(errors.New("forced")),
+			expectedStatus: 500,
+			expectedCalls:  1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := http.Config{
+				Logger: zap.NewNop(),
+				Services: http.Services{
+					UserService: c.userService,
+				},
+			}
+
+			s := httptest.NewServer(http.BuildRoutes(cfg))
+			defer s.Close()
+			url := fmt.Sprintf("%s/user?%s", s.URL, c.query)
+			req, err := stdhttp.NewRequest("GET", url, nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err)
+			}
+
+			res, err := stdhttp.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("failed to send request: %s", err)
+			}
+
+			if res.StatusCode != c.expectedStatus {
+				t.Fatalf("expected status code of %d, but got %d", c.expectedStatus, res.StatusCode)
+			}
+
+			if c.userService.ListUsersCalled != c.expectedCalls {
+				t.Fatalf("expected FetchUser user to be called %d times, but it was called %d times", c.expectedCalls, c.userService.CreateUserCalled)
+			}
+		})
+	}
+}
+
+func Test_HandleUserDelete(t *testing.T) {
+	cases := []struct {
+		name           string
+		id             string
+		userService    *mock.UserService
+		expectedStatus int
+		expectedCalls  int
+	}{
+		{
+			name:           "successful test",
+			id:             "c149f08b-b0fa-4a5d-8a6c-03ac992aa454",
+			userService:    mock.NewUserService(nil),
+			expectedStatus: 204,
+			expectedCalls:  1,
+		},
+		{
+			name:           "bad request",
+			id:             "123",
+			userService:    mock.NewUserService(nil),
+			expectedStatus: 400,
+			expectedCalls:  0,
+		},
+		{
+			name:           "service failure",
+			id:             "c149f08b-b0fa-4a5d-8a6c-03ac992aa454",
+			userService:    mock.NewUserService(errors.New("forced")),
+			expectedStatus: 500,
+			expectedCalls:  1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := http.Config{
+				Logger: zap.NewNop(),
+				Services: http.Services{
+					UserService: c.userService,
+				},
+			}
+
+			s := httptest.NewServer(http.BuildRoutes(cfg))
+			defer s.Close()
+			url := fmt.Sprintf("%s/user/%s", s.URL, c.id)
+			req, err := stdhttp.NewRequest("DELETE", url, nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err)
+			}
+
+			res, err := stdhttp.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("failed to send request: %s", err)
+			}
+
+			if res.StatusCode != c.expectedStatus {
+				t.Fatalf("expected status code of %d, but got %d", c.expectedStatus, res.StatusCode)
+			}
+
+			if c.userService.DeleteUserCalled != c.expectedCalls {
+				t.Fatalf("expected DeleteUser to be called %d times, but it was called %d times", c.expectedCalls, c.userService.CreateUserCalled)
+			}
+		})
+	}
+}

--- a/migrations/down.sql
+++ b/migrations/down.sql
@@ -2,6 +2,7 @@ DROP TABLE toggles;
 DROP TABLE metadata_keys;
 DROP TABLE account_users;
 DROP TABLE users;
+DROP TABLE identity_types;
 DROP TABLE accounts;
 
 DROP OWNED BY toggle;

--- a/mock/account.go
+++ b/mock/account.go
@@ -1,0 +1,92 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/togglr-io/togglr"
+	"github.com/togglr-io/togglr/uid"
+)
+
+type AccountService struct {
+	CreateAccountFn     func(ctx context.Context, account togglr.Account) (uid.UID, error)
+	CreateAccountCalled int
+
+	UpdateAccountFn     func(ctx context.Context, req togglr.UpdateAccountReq) error
+	UpdateAccountCalled int
+
+	FetchAccountFn     func(ctx context.Context, id uid.UID) (togglr.Account, error)
+	FetchAccountCalled int
+
+	ListAccountsFn     func(ctx context.Context, req togglr.ListAccountsReq) ([]togglr.Account, error)
+	ListAccountsCalled int
+
+	DeleteAccountFn     func(ctx context.Context, id uid.UID) error
+	DeleteAccountCalled int
+
+	UpdateAccountUsersFn     func(ctx context.Context, accountID uid.UID, req togglr.UpdateAccountUsersReq) error
+	UpdateAccountUsersCalled int
+
+	Error error
+}
+
+func NewAccountService(err error) *AccountService {
+	return &AccountService{Error: err}
+}
+
+func (m *AccountService) CreateAccount(ctx context.Context, account togglr.Account) (uid.UID, error) {
+	m.CreateAccountCalled++
+	if m.CreateAccountFn != nil {
+		return m.CreateAccountFn(ctx, account)
+	}
+
+	if account.ID.IsNull() {
+		return uid.New(), m.Error
+	}
+
+	return account.ID, m.Error
+}
+
+func (m *AccountService) UpdateAccount(ctx context.Context, req togglr.UpdateAccountReq) error {
+	m.UpdateAccountCalled++
+	if m.UpdateAccountFn != nil {
+		return m.UpdateAccountFn(ctx, req)
+	}
+
+	return m.Error
+}
+
+func (m *AccountService) FetchAccount(ctx context.Context, id uid.UID) (togglr.Account, error) {
+	m.FetchAccountCalled++
+	if m.FetchAccountFn != nil {
+		return m.FetchAccountFn(ctx, id)
+	}
+
+	return togglr.Account{}, m.Error
+}
+
+func (m *AccountService) ListAccounts(ctx context.Context, req togglr.ListAccountsReq) ([]togglr.Account, error) {
+	m.ListAccountsCalled++
+	if m.ListAccountsFn != nil {
+		return m.ListAccountsFn(ctx, req)
+	}
+
+	return make([]togglr.Account, 0), m.Error
+}
+
+func (m *AccountService) DeleteAccount(ctx context.Context, id uid.UID) error {
+	m.DeleteAccountCalled++
+	if m.DeleteAccountFn != nil {
+		return m.DeleteAccountFn(ctx, id)
+	}
+
+	return m.Error
+}
+
+func (m *AccountService) UpdateAccountUsers(ctx context.Context, accountID uid.UID, req togglr.UpdateAccountUsersReq) error {
+	m.UpdateAccountUsersCalled++
+	if m.UpdateAccountUsersFn != nil {
+		return m.UpdateAccountUsersFn(ctx, accountID, req)
+	}
+
+	return m.Error
+}

--- a/mock/metadata.go
+++ b/mock/metadata.go
@@ -1,0 +1,40 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/togglr-io/togglr"
+	"github.com/togglr-io/togglr/uid"
+)
+
+type MetadataService struct {
+	FetchKeysFn     func(ctx context.Context, accountID uid.UID) ([]togglr.MetadataKey, error)
+	FetchKeysCalled int
+
+	PushKeysFn     func(ctx context.Context, accountID uid.UID, keys ...string) error
+	PushKeysCalled int
+
+	Error error
+}
+
+func NewMetadataService(err error) *MetadataService {
+	return &MetadataService{Error: err}
+}
+
+func (m *MetadataService) FetchKeys(ctx context.Context, accountID uid.UID) ([]togglr.MetadataKey, error) {
+	m.FetchKeysCalled++
+	if m.FetchKeysFn != nil {
+		return m.FetchKeysFn(ctx, accountID)
+	}
+
+	return nil, m.Error
+}
+
+func (m *MetadataService) PushKeys(ctx context.Context, accountID uid.UID, keys ...string) error {
+	m.PushKeysCalled++
+	if m.PushKeysFn != nil {
+		return m.PushKeysFn(ctx, accountID, keys...)
+	}
+
+	return m.Error
+}

--- a/mock/user.go
+++ b/mock/user.go
@@ -1,0 +1,80 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/togglr-io/togglr"
+	"github.com/togglr-io/togglr/uid"
+)
+
+type UserService struct {
+	CreateUserFn     func(ctx context.Context, user togglr.User) (uid.UID, error)
+	CreateUserCalled int
+
+	UpdateUserFn     func(ctx context.Context, req togglr.UpdateUserReq) error
+	UpdateUserCalled int
+
+	FetchUserFn     func(ctx context.Context, id uid.UID) (togglr.User, error)
+	FetchUserCalled int
+
+	ListUsersFn     func(ctx context.Context, req togglr.ListUsersReq) ([]togglr.User, error)
+	ListUsersCalled int
+
+	DeleteUserFn     func(ctx context.Context, id uid.UID) error
+	DeleteUserCalled int
+
+	Error error
+}
+
+func NewUserService(err error) *UserService {
+	return &UserService{Error: err}
+}
+
+func (m *UserService) CreateUser(ctx context.Context, user togglr.User) (uid.UID, error) {
+	m.CreateUserCalled++
+	if m.CreateUserFn != nil {
+		return m.CreateUserFn(ctx, user)
+	}
+
+	if user.ID.IsNull() {
+		return uid.New(), m.Error
+	}
+
+	return user.ID, m.Error
+}
+
+func (m *UserService) UpdateUser(ctx context.Context, req togglr.UpdateUserReq) error {
+	m.UpdateUserCalled++
+	if m.UpdateUserFn != nil {
+		return m.UpdateUserFn(ctx, req)
+	}
+
+	return m.Error
+}
+
+func (m *UserService) FetchUser(ctx context.Context, id uid.UID) (togglr.User, error) {
+	m.FetchUserCalled++
+	if m.FetchUserFn != nil {
+		return m.FetchUserFn(ctx, id)
+	}
+
+	return togglr.User{}, m.Error
+}
+
+func (m *UserService) ListUsers(ctx context.Context, req togglr.ListUsersReq) ([]togglr.User, error) {
+	m.ListUsersCalled++
+	if m.ListUsersFn != nil {
+		return m.ListUsersFn(ctx, req)
+	}
+
+	return make([]togglr.User, 0), m.Error
+}
+
+func (m *UserService) DeleteUser(ctx context.Context, id uid.UID) error {
+	m.DeleteUserCalled++
+	if m.DeleteUserFn != nil {
+		return m.DeleteUserFn(ctx, id)
+	}
+
+	return m.Error
+}

--- a/pg/account.go
+++ b/pg/account.go
@@ -1,0 +1,124 @@
+package pg
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/togglr-io/togglr"
+	"github.com/togglr-io/togglr/uid"
+)
+
+// CreateAccount creates a new Account in postgres
+func (c Client) CreateAccount(ctx context.Context, account togglr.Account) (uid.UID, error) {
+	// if no ID is provided, generate one
+	if account.ID.IsNull() {
+		account.ID = uid.New()
+	}
+
+	query := c.db.Insert("accounts").Rows(account)
+	if _, err := query.Executor().ExecContext(ctx); err != nil {
+		return account.ID, err
+	}
+
+	return account.ID, nil
+}
+
+func (c Client) UpdateAccount(ctx context.Context, req togglr.UpdateAccountReq) error {
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create transaction: %w", err)
+	}
+
+	query := tx.Update("accounts").Set(updateReqToRecord(req)).Where(goqu.Ex{"id": req.ID})
+	if _, err := query.Executor().ExecContext(ctx); err != nil {
+		return c.handleTxErr(tx, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit: %w", err)
+	}
+
+	return nil
+}
+
+func (c Client) FetchAccount(ctx context.Context, id uid.UID) (togglr.Account, error) {
+	var account togglr.Account
+	query := c.db.From("accounts").Where(goqu.Ex{"id": id})
+	if _, err := query.ScanStructContext(ctx, &account); err != nil {
+		return account, err
+	}
+
+	return account, nil
+}
+
+// ListAccounts queries a slice of Accounts from postgres
+func (c Client) ListAccounts(ctx context.Context, req togglr.ListAccountsReq) ([]togglr.Account, error) {
+	// default to instantiated value so that we return an empty slice instead of null when there's no results
+	accounts := []togglr.Account{}
+	query := c.db.From("accounts")
+
+	if err := query.ScanStructsContext(ctx, &accounts); err != nil {
+		return nil, err
+	}
+
+	return accounts, nil
+}
+
+func (c Client) UpdateAccountUsers(ctx context.Context, accountID uid.UID, req togglr.UpdateAccountUsersReq) error {
+	// There are 4 possible cases to deal with when updating account users
+	// 1. We do nothing (e.g. Add and Remove slices are empty)
+	// 2. We _only_ add users
+	// 3. We _only_ remove users
+	// 4. We add and remove users at the same time
+
+	// first we'll short circuit on the "do nothing" case
+	if len(req.Add) == 0 && len(req.Remove) == 0 {
+		return nil
+	}
+
+	log.Printf("req: %+v", req)
+	// we have at least one query to run, so go ahead and create the tx
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	// handle the case where there are users to add
+	if len(req.Add) > 0 {
+		// because goqu tries to be generic, and go doesn't let you spread an array of one
+		// type into an array of interface{}, we have to make an array of interface{} and then
+		// assign goqu.Records to it (which is dumb, imo)
+		rows := make([]interface{}, len(req.Add))
+		for idx, userID := range req.Add {
+			rows[idx] = goqu.Record{
+				"account_id": accountID,
+				"user_id":    userID,
+			}
+		}
+		query := tx.Insert("account_users").Rows(rows...).OnConflict(goqu.DoNothing())
+		if err != nil {
+			log.Printf("failed to generate SQL: %s", err)
+			return err
+		}
+		if _, err := query.Executor().ExecContext(ctx); err != nil {
+			return c.handleTxErr(tx, err)
+		}
+	}
+
+	// handle the case where there are users to remove
+	if len(req.Remove) > 0 {
+		query := tx.Delete("account_users").Where(goqu.Ex{"account_id": accountID, "user_id": req.Remove})
+		if _, err := query.Executor().ExecContext(ctx); err != nil {
+			return c.handleTxErr(tx, err)
+		}
+	}
+
+	// commit all the things!
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit: %w", err)
+	}
+
+	return nil
+}

--- a/pg/user.go
+++ b/pg/user.go
@@ -1,0 +1,95 @@
+package pg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/togglr-io/togglr"
+	"github.com/togglr-io/togglr/uid"
+)
+
+// CreateUser creates a new User in postgres
+func (c Client) CreateUser(ctx context.Context, user togglr.User) (uid.UID, error) {
+	// if no ID is provided, generate one
+	if user.ID.IsNull() {
+		user.ID = uid.New()
+	}
+
+	query := c.db.Insert("users").Rows(user)
+	if _, err := query.Executor().ExecContext(ctx); err != nil {
+		return user.ID, err
+	}
+
+	return user.ID, nil
+}
+
+func (c Client) UpdateUser(ctx context.Context, req togglr.UpdateUserReq) error {
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create transaction: %w", err)
+	}
+
+	query := tx.Update("users").Set(updateReqToRecord(req)).Where(goqu.Ex{"id": req.ID})
+	if _, err := query.Executor().ExecContext(ctx); err != nil {
+		if rbErr := tx.Rollback(); err != nil {
+			return fmt.Errorf("rollback failed with err: %s %w", rbErr, err)
+		}
+
+		return fmt.Errorf("failed with rollback: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit: %w", err)
+	}
+
+	return nil
+}
+
+func (c Client) FetchUser(ctx context.Context, id uid.UID) (togglr.User, error) {
+	var user togglr.User
+	query := c.db.From("users").Where(goqu.Ex{"id": id})
+	if _, err := query.ScanStructContext(ctx, &user); err != nil {
+		return user, err
+	}
+
+	return user, nil
+}
+
+// ListUsers queries a slice of Users from postgres
+func (c Client) ListUsers(ctx context.Context, req togglr.ListUsersReq) ([]togglr.User, error) {
+	// default to instantiated value so that we return an empty slice instead of null when there's no results
+	if req.AccountID.IsNull() {
+		return nil, errors.New("attempted to list users without specifiying an account")
+	}
+
+	users := []togglr.User{}
+	query := c.db.
+		Select("u.*").
+		From(goqu.T("users").As("u")).
+		LeftJoin(
+			goqu.T("account_users").As("au"),
+			goqu.On(
+				goqu.Ex{
+					"au.user_id": goqu.I("u.id"),
+				},
+			),
+		)
+
+	if err := query.Where(goqu.Ex{"au.account_id": req.AccountID}).ScanStructsContext(ctx, &users); err != nil {
+		return nil, err
+	}
+
+	return users, nil
+}
+
+// DeleteUser deletes a User from postgres
+func (c Client) DeleteUser(ctx context.Context, id uid.UID) error {
+	del := c.db.Delete("users").Where(goqu.Ex{"id": id}).Executor()
+	if _, err := del.Exec(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -88,7 +88,6 @@ func Test_DefaultResolver(t *testing.T) {
 		t.Fatalf("failed to resolve toggles: %s", err)
 	}
 
-	t.Logf("resolved: %v", resolved)
 	admin, ok := resolved["admin-feature"]
 	if !ok {
 		t.Fatalf("expected 'admin-feature' flag to be present")

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -180,11 +180,11 @@ func (r Rules) Value() (driver.Value, error) {
 // Scan impelements the sql.Scanner interface
 func (r *Rules) Scan(src interface{}) error {
 	var source []byte
-	switch src.(type) {
+	switch val := src.(type) {
 	case string:
-		source = []byte(src.(string))
+		source = []byte(val)
 	case []byte:
-		source = src.([]byte)
+		source = val
 	case nil:
 		source = nil
 	default:

--- a/rules/unary.go
+++ b/rules/unary.go
@@ -26,3 +26,13 @@ func (u Unary) Evaluate(md Metadata) Comparable {
 
 	return NewBool(val.IsTrue())
 }
+
+func (u Unary) MarshalJSON() ([]byte, error) {
+	// TODO (etate): implement once we actually use unary expressions
+	return nil, nil
+}
+
+func (u *Unary) UnmarshalJSON(data []byte) error {
+	// TODO (etate): implement once we actually use unary expressions
+	return nil
+}

--- a/toggleService.go
+++ b/toggleService.go
@@ -34,9 +34,9 @@ func extractKeys(expr rules.Expr) []string {
 	case rules.Expression:
 		switch v.Type {
 		case rules.ExprTypeBinary:
-			keys = append(extractKeys(v.Binary))
+			keys = append(keys, extractKeys(v.Binary)...)
 		case rules.ExprTypeIdent:
-			keys = append(extractKeys(v.Ident))
+			keys = append(keys, extractKeys(v.Ident)...)
 		}
 	case rules.Binary:
 		keys = append(keys, extractKeys(v.Left)...)

--- a/toggleService.go
+++ b/toggleService.go
@@ -69,6 +69,7 @@ func (s DefaultToggleService) CreateToggle(ctx context.Context, toggle Toggle) (
 	// push keys asynchronously so we don't keep the caller waiting
 	go s.pushKeys(ctx, toggle.AccountID, toggle.Rules)
 
+	toggle.ID = uid.New()
 	return s.ts.CreateToggle(ctx, toggle)
 }
 

--- a/toggleService_test.go
+++ b/toggleService_test.go
@@ -1,0 +1,97 @@
+package togglr_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/togglr-io/togglr"
+	"github.com/togglr-io/togglr/mock"
+	"github.com/togglr-io/togglr/rules"
+	"github.com/togglr-io/togglr/uid"
+	"go.uber.org/zap"
+)
+
+func Test_DefaultToggleService(t *testing.T) {
+	// SETUP
+	ms := mock.NewMetadataService(nil)
+	mockTS := mock.NewToggleService(nil)
+	ts := togglr.NewToggleService(mockTS, ms, zap.NewNop())
+
+	rules := rules.Rules{
+		{
+			Expr: rules.Expression{
+				Type: rules.ExprTypeBinary,
+				Binary: rules.NewBinary(
+					rules.NewIdent("test-key"),
+					rules.NewString("test-value"),
+					rules.BinOpEq,
+				),
+			},
+		},
+		{
+			Expr: rules.Expression{
+				Type: rules.ExprTypeBinary,
+				Binary: rules.NewBinary(
+					rules.NewIdent("another-key"),
+					rules.NewString("another-value"),
+					rules.BinOpEq,
+				),
+			},
+		},
+	}
+
+	expectedKeys := []string{"test-key", "another-key"}
+
+	toggle := togglr.Toggle{
+		Key:   "test-toggle",
+		Rules: rules,
+	}
+
+	wg := sync.WaitGroup{}
+	ms.PushKeysFn = func(ctx context.Context, accountID uid.UID, keys ...string) error {
+		defer wg.Done()
+		var found bool
+		for _, expected := range expectedKeys {
+			found = false
+			for _, key := range keys {
+				if key == expected {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				t.Fatalf("expected key %s", expected)
+			}
+		}
+
+		return nil
+	}
+
+	// RUN
+	wg.Add(2)
+	_, err := ts.CreateToggle(context.TODO(), toggle)
+	if err != nil {
+		t.Fatalf("failed to create toggle: %s", err)
+	}
+	err = ts.UpdateToggle(context.TODO(), togglr.UpdateToggleReq{
+		Rules: rules,
+	})
+	if err != nil {
+		t.Fatalf("failed to update toggle: %s", err)
+	}
+	wg.Wait()
+
+	if ms.PushKeysCalled != 2 {
+		t.Fatalf("expected MetadataService.PushKeys to be called 1 time, not %d", ms.PushKeysCalled)
+	}
+
+	if mockTS.CreateToggleCalled != 1 {
+		t.Fatalf("expected ToggleService.CreateTogggle to be called 1 time, not %d", mockTS.CreateToggleCalled)
+	}
+
+	if mockTS.UpdateToggleCalled != 1 {
+		t.Fatalf("expected ToggleService.UpdateTogggle to be called 1 time, not %d", mockTS.UpdateToggleCalled)
+	}
+}

--- a/togglr.go
+++ b/togglr.go
@@ -8,22 +8,43 @@ import (
 	"github.com/togglr-io/togglr/uid"
 )
 
+// An IdentityType determines what type of authN is associated with a given User.
+type IdentityType string
+
+// Enumeration of possible IdentityTypes
+const (
+	IdentityTypeGithub = IdentityType("github")
+	IdentityTypeBasic  = IdentityType("basic")
+	IdentityTypeGoogle = IdentityType("google")
+)
+
 // An ID is a wrapper struct for working with JSON payloads containing
 // an ID. This is used to differentiate between creates and updates
-// as well as a return type for certain operations.
+// as well as a return type for certain operations
 type ID struct {
 	ID uid.UID `json:"id"`
 }
 
-// An Account represents a grouping of Users and Toggles.
+// An Account represents a grouping of Users and Toggles
 type Account struct {
 	ID        uid.UID   `json:"id" db:"id"`
 	Name      string    `json:"name" db:"name"`
-	CreatedAt time.Time `json:"createdAt" db:"created_at"`
-	UpdatedAt time.Time `json:"updatedAt" db:"updated_at"`
+	CreatedAt time.Time `json:"createdAt" db:"created_at" goqu:"skipinsert,skipupdate"`
+	UpdatedAt time.Time `json:"updatedAt" db:"updated_at" goqu:"skipinsert,skipupdate"`
 }
 
-// A Toggle represents a key and the set of rules that determine the value that should be returned for it.
+// A User represents a single User interacting with Togglr. Users can belong to multiple
+// accounts and a User will be attached to every request to make decisions around authZ
+type User struct {
+	ID        uid.UID      `json:"id" db:"id"`
+	Name      string       `json:"name" db:"name"`
+	Email     string       `json:"email" db:"email"`
+	Identity  IdentityType `json:"-" db:"identity_type"`
+	CreatedAt time.Time    `json:"createdAt" db:"created_at" goqu:"skipinsert,skipupdate"`
+	UpdatedAt time.Time    `json:"updatedAt" db:"updated_at" goqu:"skipinsert,skipupdate"`
+}
+
+// A Toggle represents a key and the set of rules that determine the value that should be returned for it
 type Toggle struct {
 	ID          uid.UID     `json:"id" db:"id"`
 	AccountID   uid.UID     `json:"accountId" db:"account_id"`
@@ -31,8 +52,8 @@ type Toggle struct {
 	Description string      `json:"description" db:"description"`
 	Active      bool        `json:"active" db:"active"`
 	Rules       rules.Rules `json:"rules" db:"rules"`
-	CreatedAt   time.Time   `json:"createdAt" db:"created_at" goqu:"skipinsert"`
-	UpdatedAt   time.Time   `json:"updatedAt" db:"updated_at" goqu:"skipinsert"`
+	CreatedAt   time.Time   `json:"createdAt" db:"created_at" goqu:"skipinsert,skipupdate"`
+	UpdatedAt   time.Time   `json:"updatedAt" db:"updated_at" goqu:"skipinsert,skipupdate"`
 }
 
 // An UpdateToggleReq contains all of the fields that are possible to update on a Toggle. The main difference from
@@ -47,12 +68,12 @@ type UpdateToggleReq struct {
 	Rules       rules.Rules `json:"rules" db:"rules"`
 }
 
-// ListTogglesReq defines the search parameters that will be used when generating a list of toggles.
+// ListTogglesReq defines the search parameters that will be used when generating a list of toggles
 type ListTogglesReq struct {
 	AccountID uid.UID `json:"accountId" db:"account_id"`
 }
 
-// A ToggleService performs basic CRUD operations on toggles.
+// A ToggleService performs basic CRUD operations on toggles
 type ToggleService interface {
 	CreateToggle(ctx context.Context, toggle Toggle) (uid.UID, error)
 	UpdateToggle(ctx context.Context, req UpdateToggleReq) error
@@ -62,7 +83,7 @@ type ToggleService interface {
 }
 
 // A MetadataKey represents a key that an account has used before. It's primary purpose is
-// populating option lists.
+// populating option lists
 type MetadataKey struct {
 	ID        uid.UID   `json:"id" db:"id"`
 	AccountID uid.UID   `json:"accountId" db:"account_id"`
@@ -71,7 +92,7 @@ type MetadataKey struct {
 	UpdatedAt time.Time `json:"updatedAt" db:"updated_at" goqu:"skipinsert"`
 }
 
-// A MetadataService works with various aspects of Metadata within Togglr.
+// A MetadataService works with various aspects of Metadata within Togglr
 type MetadataService interface {
 	FetchKeys(ctx context.Context, accountID uid.UID) ([]MetadataKey, error)
 	PushKeys(ctx context.Context, accountID uid.UID, key ...string) error
@@ -82,7 +103,14 @@ type MetadataService interface {
 type ResolvedToggles map[string]bool
 
 // A Resolver returns a map of resolved toggles for a given account
-// using the given Metadata.
+// using the given Metadata
 type Resolver interface {
 	Resolve(ctx context.Context, accountID uid.UID, metdata rules.Metadata) (ResolvedToggles, error)
+}
+
+// A Signer signs and validates the signature of some data. Validating
+// should also return the original data.
+type Signer interface {
+	Sign(data []byte) ([]byte, error)
+	Validate(data []byte) ([]byte, error)
 }


### PR DESCRIPTION
- Adds basic account CRUD
- Adds basic user CRUD
- Allows for assigning/removing users to/from accounts
- Adds `golangci-lint` config
- Adds basic HMAC signing to be used for account invitations